### PR TITLE
Added a skip feature for code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "esbuild": "0.19.12",
-    "obsidian": "latest"
+    "obsidian": "^1.12.3"
   }
 }

--- a/src/commands/linking.js
+++ b/src/commands/linking.js
@@ -26,7 +26,14 @@ async function linkKeywordsInCurrentNote(app, settings, linkKeywordsInFile, save
     }
 
     // Process the file and get results
-    const results = await linkKeywordsInFile(activeFile, preview);
+    let results;
+    try {
+        results = await linkKeywordsInFile(activeFile, preview);
+    } catch (err) {
+        console.error('Auto Keyword Linker: Error linking keywords in current note:', err);
+        new Notice(`Error linking keywords: ${err.message}`);
+        return;
+    }
 
     // If preview mode and we have results, show preview modal
     if (preview && results) {
@@ -77,7 +84,13 @@ async function linkKeywordsInAllNotes(app, settings, linkKeywordsInFile, saveSet
             continue;
         }
 
-        const results = await linkKeywordsInFile(file, preview);
+        let results;
+        try {
+            results = await linkKeywordsInFile(file, preview);
+        } catch (err) {
+            console.error(`Auto Keyword Linker: Error processing ${file.path}:`, err);
+            continue;
+        }
 
         // If changes were made to this file
         if (results && results.changed) {

--- a/src/core/KeywordLinker.js
+++ b/src/core/KeywordLinker.js
@@ -1,6 +1,6 @@
 const { MarkdownView } = require('obsidian');
 const { escapeRegex, getContext } = require('../utils/helpers');
-const { getFrontmatterBounds, isInsideAlias, isPartOfUrl, isInsideLinkOrCode, isInsideBlockReference, isInsideTable, isInsideMath, isInsideHeading } = require('../utils/detection');
+const { getFrontmatterBounds, isInsideAlias, isPartOfUrl, isInsideLinkOrCode, isInsideBlockReference, isInsideTable, isInsideMath, isInsideHeading, isInsideFencedCodeBlock } = require('../utils/detection');
 const { getEffectiveKeywordSettings, buildKeywordMap, checkLinkScope } = require('../utils/linking');
 const { findTargetFile, getAliasesForNote, noteHasTag, noteHasLinkToTarget, ensureNoteExists } = require('../utils/noteManagement');
 const { sanitizeTagName, addTagsToContent, addTagToTargetNote } = require('../utils/tagManagement');
@@ -59,6 +59,11 @@ class KeywordLinker {
             const suggestMode = keywordMap[keyword].suggestMode || false;
             const preventSelfLink = keywordMap[keyword].preventSelfLink || false;
             const keywordIndex = keywordMap[keyword].keywordIndex;
+            // Per-keyword skipCodeBlocks: null means inherit global, true/false overrides
+            const perKeywordSkip = keywordMap[keyword].skipCodeBlocks;
+            const skipCodeBlocks = perKeywordSkip !== null && perKeywordSkip !== undefined
+                ? perKeywordSkip
+                : (this.settings.skipCodeBlocks || false);
 
             // Skip empty keywords or targets
             if (!keyword.trim() || !target || !target.trim()) continue;
@@ -110,6 +115,11 @@ class KeywordLinker {
 
                 // Skip if on a heading line (e.g. ## My Heading)
                 if (this.settings.skipHeadings && isInsideHeading(content, matchIndex)) {
+                    continue;
+                }
+
+                // Skip if inside a fenced code block (``` or ~~~)
+                if (skipCodeBlocks && isInsideFencedCodeBlock(content, matchIndex)) {
                     continue;
                 }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -31,6 +31,18 @@ async function loadSettings(plugin) {
         settings.keywordGroups = [];
     }
 
+    // Ensure skipCodeBlocks exists in each group's settings (migration for existing groups)
+    for (let group of settings.keywordGroups) {
+        if (group.settings && group.settings.skipCodeBlocks === undefined) {
+            group.settings.skipCodeBlocks = false;
+        }
+    }
+
+    // Ensure skipCodeBlocks exists (migration for existing users)
+    if (settings.skipCodeBlocks === undefined) {
+        settings.skipCodeBlocks = DEFAULT_SETTINGS.skipCodeBlocks;
+    }
+
     // Ensure enableTags, linkScope, id, and groupId fields exist for all keywords
     if (settings.keywords) {
         for (let keyword of settings.keywords) {
@@ -83,6 +95,12 @@ async function loadSettings(plugin) {
             }
             if (keyword.groupId && keyword.useRelativeLinks === false) {
                 keyword.useRelativeLinks = null;
+            }
+            if (keyword.skipCodeBlocks === undefined) {
+                keyword.skipCodeBlocks = null;
+            }
+            if (keyword.groupId && keyword.skipCodeBlocks === false) {
+                keyword.skipCodeBlocks = null;
             }
         }
     }

--- a/src/ui/settings/AutoKeywordLinkerSettingTab.js
+++ b/src/ui/settings/AutoKeywordLinkerSettingTab.js
@@ -269,7 +269,8 @@ class AutoKeywordLinkerSettingTab extends PluginSettingTab {
                     requireTag: '',
                     onlyInNotesLinkingTo: false,
                     suggestMode: false,
-                    preventSelfLink: false
+                    preventSelfLink: false,
+                    skipCodeBlocks: false
                 }
             });
             // Re-render the display to show new entry
@@ -328,6 +329,17 @@ class AutoKeywordLinkerSettingTab extends PluginSettingTab {
                 .setValue(this.plugin.settings.skipHeadings)
                 .onChange(async (value) => {
                     this.plugin.settings.skipHeadings = value;
+                    await this.plugin.saveSettings();
+                }));
+
+        // Skip code blocks toggle (global)
+        new Setting(containerEl)
+            .setName('Skip code blocks')
+            .setDesc('Prevent keywords from being linked or suggested inside fenced code blocks (``` or ~~~). Can be overridden per keyword or per group.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.skipCodeBlocks || false)
+                .onChange(async (value) => {
+                    this.plugin.settings.skipCodeBlocks = value;
                     await this.plugin.saveSettings();
                 }));
 
@@ -988,6 +1000,33 @@ class AutoKeywordLinkerSettingTab extends PluginSettingTab {
                 preventSelfLinkSetting.settingEl.addClass('akl-disabled-setting');
             }
 
+            // Skip code blocks toggle (per-keyword)
+            const skipCodeBlocksSetting = new Setting(cardBody)
+                .setName('Skip code blocks')
+                .setDesc(isInGroup
+                    ? `Inherited from group "${groupName}"`
+                    : 'Prevent this keyword from being linked or suggested inside fenced code blocks. "Inherit" uses the global setting.')
+                .addDropdown(dropdown => {
+                    const effectiveSettings = this.plugin.getEffectiveKeywordSettings(item);
+                    // null = inherit global, true = always skip, false = never skip (override global)
+                    const currentVal = isInGroup ? String(effectiveSettings.skipCodeBlocks || false) : String(item.skipCodeBlocks);
+                    dropdown
+                        .addOption('null', 'Inherit global setting')
+                        .addOption('true', 'Always skip code blocks')
+                        .addOption('false', 'Never skip code blocks')
+                        .setValue(currentVal === 'null' || currentVal === 'undefined' ? 'null' : currentVal)
+                        .setDisabled(isInGroup)
+                        .onChange(async (value) => {
+                            if (!isInGroup) {
+                                this.plugin.settings.keywords[i].skipCodeBlocks = value === 'null' ? null : value === 'true';
+                                await this.plugin.saveSettings();
+                            }
+                        });
+                });
+            if (isInGroup) {
+                skipCodeBlocksSetting.settingEl.addClass('akl-disabled-setting');
+            }
+
             // Link Scope dropdown
             const linkScopeSetting = new Setting(cardBody)
                 .setName('Link scope')
@@ -1285,6 +1324,17 @@ class AutoKeywordLinkerSettingTab extends PluginSettingTab {
                     .setValue(group.settings.preventSelfLink || false)
                     .onChange(async (value) => {
                         group.settings.preventSelfLink = value;
+                        await this.plugin.saveSettings();
+                    }));
+
+            // Skip code blocks toggle
+            new Setting(settingsSection)
+                .setName('Skip code blocks')
+                .setDesc('Prevent keywords in this group from being linked or suggested inside fenced code blocks (``` or ~~~)')
+                .addToggle(toggle => toggle
+                    .setValue(group.settings.skipCodeBlocks || false)
+                    .onChange(async (value) => {
+                        group.settings.skipCodeBlocks = value;
                         await this.plugin.saveSettings();
                     }));
         }

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -24,6 +24,16 @@ function getStopWords(settings) {
 }
 
 /**
+ * Remove fenced code blocks (``` and ~~~) from text before analysis
+ * @param {string} text - Text to strip code blocks from
+ * @returns {string} Text with code block contents replaced by empty lines
+ */
+function stripFencedCodeBlocks(text) {
+    // Replace ``` and ~~~ fenced blocks (with optional language identifier) with empty string
+    return text.replace(/^(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\s*$/gm, '');
+}
+
+/**
  * Extract meaningful words from text
  * @param {string} text - Text to extract words from
  * @param {boolean} isTitle - Whether this is a title (affects processing)
@@ -171,6 +181,11 @@ async function analyzeNotesForKeywords(app, settings, getAliasesForNote) {
             // Remove frontmatter
             let contentWithoutFrontmatter = limitedContent.replace(/^---[\s\S]*?---\n/, '');
 
+            // Remove fenced code blocks if setting is enabled
+            if (settings.skipCodeBlocks) {
+                contentWithoutFrontmatter = stripFencedCodeBlocks(contentWithoutFrontmatter);
+            }
+
             // Remove all wikilinks [[link]] and [[link|alias]] - they're already keywords or shouldn't be suggested
             contentWithoutFrontmatter = contentWithoutFrontmatter.replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, '');
 
@@ -313,6 +328,11 @@ async function analyzeCurrentNoteForKeywords(app, settings, file, getAliasesForN
 
         // Remove frontmatter
         let contentWithoutFrontmatter = content.replace(/^---[\s\S]*?---\n/, '');
+
+        // Remove fenced code blocks if setting is enabled
+        if (settings.skipCodeBlocks) {
+            contentWithoutFrontmatter = stripFencedCodeBlocks(contentWithoutFrontmatter);
+        }
 
         // Remove all wikilinks [[link]] and [[link|alias]] - they're already keywords or shouldn't be suggested
         contentWithoutFrontmatter = contentWithoutFrontmatter.replace(/\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g, '');

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -44,6 +44,7 @@ const DEFAULT_SETTINGS = {
     customStopWords: [],             // Additional stop words to exclude from keyword suggestions (appended to defaults)
     preventSelfLinkGlobal: false,    // Global setting: prevent linking keywords on their target notes
     skipHeadings: true,              // Skip keyword linking on Markdown heading lines (## Heading)
+    skipCodeBlocks: false,           // Skip keyword linking and suggestions inside fenced code blocks (``` or ~~~)
     statistics: {                    // Statistics tracking
         totalLinksCreated: 0,
         totalNotesProcessed: 0,

--- a/src/utils/detection.js
+++ b/src/utils/detection.js
@@ -463,6 +463,50 @@ function isInsideTable(content, index) {
 }
 
 /**
+ * Check if a position is inside a fenced code block (``` or ~~~)
+ * Handles both ``` and ~~~ style fences, with optional language identifiers
+ * @param {string} content - The full content
+ * @param {number} index - Position to check
+ * @returns {boolean} True if inside a fenced code block
+ */
+function isInsideFencedCodeBlock(content, index) {
+    const lines = content.split('\n');
+    let charPos = 0;
+    let insideFence = false;
+    let fenceChar = null; // '`' or '~'
+
+    for (let i = 0; i < lines.length; i++) {
+        const lineEnd = charPos + lines[i].length;
+
+        // Check if our target index is on this line
+        const targetOnThisLine = index >= charPos && index <= lineEnd;
+
+        // Detect fence open/close: line starts with ``` or ~~~
+        const fenceMatch = lines[i].match(/^(`{3,}|~{3,})/);
+        if (fenceMatch) {
+            const thisFenceChar = fenceMatch[1][0];
+            if (!insideFence) {
+                // If our index is on the fence opening line itself, not inside content
+                if (targetOnThisLine) return false;
+                insideFence = true;
+                fenceChar = thisFenceChar;
+            } else if (thisFenceChar === fenceChar) {
+                // Closing fence
+                if (targetOnThisLine) return false;
+                insideFence = false;
+                fenceChar = null;
+            }
+        } else if (targetOnThisLine) {
+            return insideFence;
+        }
+
+        charPos = lineEnd + 1; // +1 for the newline
+    }
+
+    return insideFence;
+}
+
+/**
  * Check if a position is on a Markdown heading line (lines starting with one or more #)
  * @param {string} content - The full content
  * @param {number} index - Position to check
@@ -491,5 +535,6 @@ module.exports = {
     isInsideBlockReference,
     isInsideTable,
     isInsideMath,
-    isInsideHeading
+    isInsideHeading,
+    isInsideFencedCodeBlock
 };

--- a/src/utils/linking.js
+++ b/src/utils/linking.js
@@ -22,7 +22,8 @@ function getEffectiveKeywordSettings(settings, keyword) {
         requireTag: '',
         onlyInNotesLinkingTo: false,
         suggestMode: false,
-        preventSelfLink: false
+        preventSelfLink: false,
+        skipCodeBlocks: null
     };
 
     // If keyword is in a group, use group settings (no keyword-level overrides allowed)
@@ -46,6 +47,7 @@ function getEffectiveKeywordSettings(settings, keyword) {
     if (keyword.onlyInNotesLinkingTo !== null && keyword.onlyInNotesLinkingTo !== undefined) effectiveSettings.onlyInNotesLinkingTo = keyword.onlyInNotesLinkingTo;
     if (keyword.suggestMode !== null && keyword.suggestMode !== undefined) effectiveSettings.suggestMode = keyword.suggestMode;
     if (keyword.preventSelfLink !== null && keyword.preventSelfLink !== undefined) effectiveSettings.preventSelfLink = keyword.preventSelfLink;
+    if (keyword.skipCodeBlocks !== null && keyword.skipCodeBlocks !== undefined) effectiveSettings.skipCodeBlocks = keyword.skipCodeBlocks;
 
     return effectiveSettings;
 }
@@ -67,8 +69,7 @@ function buildKeywordMap(app, settings) {
 
         // Check if we've already seen this keyword (case-insensitive)
         if (seenKeywords.has(lowerKey)) {
-            // Skip duplicate - first one wins
-            console.warn(`Auto Keyword Linker: Skipping duplicate keyword "${keywordText}" (already have "${seenKeywords.get(lowerKey)}")`);
+            // Skip duplicate - first one wins (silent, duplicates are a user data issue)
             return false;
         }
 

--- a/src/utils/noteManagement.js
+++ b/src/utils/noteManagement.js
@@ -273,8 +273,16 @@ async function ensureNoteExists(app, settings, noteName) {
         }
     }
 
-    // Create the new note
-    await app.vault.create(path, content);
+    // Create the new note — guard against race condition where another
+    // concurrent call already created it between our existence check and here
+    try {
+        await app.vault.create(path, content);
+    } catch (err) {
+        if (!err.message || !err.message.includes('File already exists')) {
+            throw err;
+        }
+        // Another concurrent call beat us to it — that's fine, note now exists
+    }
 }
 
 /**


### PR DESCRIPTION
Adds a "Skip code blocks" option at three levels of granularity. A global toggle in the General tab prevents keywords from being linked or suggested inside fenced code blocks (``` or ~~~) across the entire vault. Individual keywords can override this with an "Inherit / Always skip / Never skip" dropdown, and keyword groups have their own toggle that applies to all keywords in the group. The suggestion builder also respects the global setting, so words inside code blocks won't pollute keyword suggestions when the option is enabled. Also fixes a crash in "Link all notes" when auto-create notes is enabled and multiple target notes are created concurrently. Fixes #58 